### PR TITLE
small Registry map receiver improvement 

### DIFF
--- a/module/registry.go
+++ b/module/registry.go
@@ -22,9 +22,9 @@ func Register(name string, creator Creator) {
 }
 
 // Register registers a module
-func (r *Registry) Register(name string, creator Creator) {
-	if _, ok := (*r)[name]; ok {
+func (r Registry) Register(name string, creator Creator) {
+	if _, ok := r[name]; ok {
 		panic(fmt.Sprintf("%s is already in registry", name))
 	}
-	(*r)[name] = creator
+	r[name] = creator
 }


### PR DESCRIPTION
A non-nil map, unlike slices, is a pointer to the standard *hmap structure, it shouldn't be passed as a receiver pointer on its methods.

```go
type hmap struct {
	// Note: the format of the hmap is also encoded in cmd/compile/internal/gc/reflect.go.
	// Make sure this stays in sync with the compiler's definition.
	count     int // # live cells == size of map.  Must be first (used by len() builtin)
	flags     uint8
	B         uint8  // log_2 of # of buckets (can hold up to loadFactor * 2^B items)
	noverflow uint16 // approximate number of overflow buckets; see incrnoverflow for details
	hash0     uint32 // hash seed

	buckets    unsafe.Pointer // array of 2^B Buckets. may be nil if count==0.
	oldbuckets unsafe.Pointer // previous bucket array of half the size, non-nil only when growing
	nevacuate  uintptr        // progress counter for evacuation (buckets less than this have been evacuated)

	extra *mapextra // optional fields
}
```

source: https://github.com/golang/go/blob/ed15e82413c7b16e21a493f5a647f68b46e965ee/src/runtime/map.go#L115-L129