### PR TITLE
fix: call cleanup when check is failed

### DIFF
--- a/module/job.go
+++ b/module/job.go
@@ -124,16 +124,20 @@ func (j *Job) Init() bool {
 
 // Check calls module Check and returns its value.
 // It handles panic. In case of panic it calls module Cleanup.
-func (j *Job) Check() bool {
+func (j *Job) Check() (ok bool) {
 	defer func() {
 		if r := recover(); r != nil {
+			ok = false
 			j.Errorf("PANIC %v", r)
 			j.panicked = true
 			j.module.Cleanup()
 		}
 	}()
-
-	return j.module.Check()
+	ok = j.module.Check()
+	if !ok {
+		j.module.Cleanup()
+	}
+	return
 }
 
 // PostCheck calls module Charts.

--- a/module/job_test.go
+++ b/module/job_test.go
@@ -127,7 +127,7 @@ func TestJob_Check(t *testing.T) {
 
 	assert.False(t, job.Check())
 	assert.False(t, job.Panicked())
-	assert.False(t, m.CleanupDone)
+	assert.True(t, m.CleanupDone)
 
 	// PANIC case
 	m = &MockModule{

--- a/module/mock.go
+++ b/module/mock.go
@@ -46,7 +46,7 @@ func (m MockModule) Collect() map[string]int64 {
 
 // Cleanup sets CleanupDone to true
 func (m *MockModule) Cleanup() {
-	if m.ChartsFunc != nil {
+	if m.CleanupFunc != nil {
 		m.CleanupFunc()
 	}
 	m.CleanupDone = true

--- a/module/mock.go
+++ b/module/mock.go
@@ -8,6 +8,7 @@ type MockModule struct {
 	CheckFunc   func() bool
 	ChartsFunc  func() *Charts
 	CollectFunc func() map[string]int64
+	CleanupFunc func()
 	CleanupDone bool
 }
 
@@ -45,5 +46,8 @@ func (m MockModule) Collect() map[string]int64 {
 
 // Cleanup sets CleanupDone to true
 func (m *MockModule) Cleanup() {
+	if m.ChartsFunc != nil {
+		m.CleanupFunc()
+	}
 	m.CleanupDone = true
 }

--- a/orchestrator_test.go
+++ b/orchestrator_test.go
@@ -78,6 +78,7 @@ func TestOrchestrator_lifecycle(t *testing.T) {
 	for _, job := range o.loopQueue.queue {
 		job.Stop()
 	}
+	time.Sleep(time.Second)
 
 	assert.Equal(t, 1, counter["normal_init"])
 	assert.Equal(t, 1, counter["fail_init"])

--- a/orchestrator_test.go
+++ b/orchestrator_test.go
@@ -26,21 +26,28 @@ func TestOrchestrator_lifecycle(t *testing.T) {
 	o := New()
 	o.Name = "test.d"
 
+	var mtx sync.Mutex
 	counter := map[string]int{}
 
 	mod := func(name string) module.Module {
 		return &module.MockModule{
 			InitFunc: func() bool {
+				mtx.Lock()
+				defer mtx.Unlock()
 				counter[name+"_init"]++
 				log.Infof("[%s] init", name)
 				return true
 			},
 			CheckFunc: func() bool {
+				mtx.Lock()
+				defer mtx.Unlock()
 				counter[name+"_check"]++
 				log.Infof("[%s] check", name)
 				return name != "fail"
 			},
 			ChartsFunc: func() *module.Charts {
+				mtx.Lock()
+				defer mtx.Unlock()
 				counter[name+"_charts"]++
 				log.Infof("[%s] charts", name)
 				return &module.Charts{
@@ -48,11 +55,15 @@ func TestOrchestrator_lifecycle(t *testing.T) {
 				}
 			},
 			CollectFunc: func() map[string]int64 {
+				mtx.Lock()
+				defer mtx.Unlock()
 				counter[name+"_collect"]++
 				log.Infof("[%s] collect", name)
 				return map[string]int64{"id1": 1}
 			},
 			CleanupFunc: func() {
+				mtx.Lock()
+				defer mtx.Unlock()
 				counter[name+"_cleanup"]++
 				log.Infof("[%s] cleanup", name)
 			},

--- a/orchestrator_test.go
+++ b/orchestrator_test.go
@@ -91,16 +91,20 @@ func TestOrchestrator_lifecycle(t *testing.T) {
 	}
 	time.Sleep(time.Second)
 
-	assert.Equal(t, 1, counter["normal_init"])
-	assert.Equal(t, 1, counter["fail_init"])
-	assert.Equal(t, 1, counter["normal_check"])
-	assert.Equal(t, 1, counter["fail_check"])
-	assert.Equal(t, 1, counter["normal_charts"])
-	assert.Equal(t, 0, counter["fail_charts"])
-	assert.Equal(t, 2, counter["normal_collect"])
-	assert.Equal(t, 0, counter["fail_collect"])
-	assert.Equal(t, 1, counter["normal_cleanup"])
-	assert.Equal(t, 1, counter["fail_cleanup"])
+	func() {
+		mtx.Lock()
+		defer mtx.Unlock()
+		assert.Equal(t, 1, counter["normal_init"])
+		assert.Equal(t, 1, counter["fail_init"])
+		assert.Equal(t, 1, counter["normal_check"])
+		assert.Equal(t, 1, counter["fail_check"])
+		assert.Equal(t, 1, counter["normal_charts"])
+		assert.Equal(t, 0, counter["fail_charts"])
+		assert.Equal(t, 2, counter["normal_collect"])
+		assert.Equal(t, 0, counter["fail_collect"])
+		assert.Equal(t, 1, counter["normal_cleanup"])
+		assert.Equal(t, 1, counter["fail_cleanup"])
+	}()
 }
 
 func TestOrchestrator_Serve(t *testing.T) {

--- a/orchestrator_test.go
+++ b/orchestrator_test.go
@@ -22,6 +22,75 @@ func TestNew(t *testing.T) {
 	assert.NotNil(t, o.Config)
 }
 
+func TestOrchestrator_lifecycle(t *testing.T) {
+	o := New()
+	o.Name = "test.d"
+
+	counter := map[string]int{}
+
+	mod := func(name string) module.Module {
+		return &module.MockModule{
+			InitFunc: func() bool {
+				counter[name+"_init"]++
+				log.Infof("[%s] init", name)
+				return true
+			},
+			CheckFunc: func() bool {
+				counter[name+"_check"]++
+				log.Infof("[%s] check", name)
+				return name != "fail"
+			},
+			ChartsFunc: func() *module.Charts {
+				counter[name+"_charts"]++
+				log.Infof("[%s] charts", name)
+				return &module.Charts{
+					&module.Chart{ID: "id", Title: "title", Units: "units", Dims: module.Dims{{ID: "id1"}}},
+				}
+			},
+			CollectFunc: func() map[string]int64 {
+				counter[name+"_collect"]++
+				log.Infof("[%s] collect", name)
+				return map[string]int64{"id1": 1}
+			},
+			CleanupFunc: func() {
+				counter[name+"_cleanup"]++
+				log.Infof("[%s] cleanup", name)
+			},
+		}
+	}
+
+	o.Option = &cli.Option{Module: "all"}
+	o.ConfigPath = multipath.New("./testdata")
+	o.Registry = module.Registry{
+		"normal": module.Creator{Create: func() module.Module { return mod("normal") }},
+		"fail":   module.Creator{Create: func() module.Module { return mod("fail") }},
+	}
+	o.configName = "test.d.conf.yml"
+
+	require.True(t, o.Setup())
+
+	go o.Serve()
+
+	time.Sleep(time.Second * 2)
+
+	o.stop()
+
+	for _, job := range o.loopQueue.queue {
+		job.Stop()
+	}
+
+	assert.Equal(t, 1, counter["normal_init"])
+	assert.Equal(t, 1, counter["fail_init"])
+	assert.Equal(t, 1, counter["normal_check"])
+	assert.Equal(t, 1, counter["fail_check"])
+	assert.Equal(t, 1, counter["normal_charts"])
+	assert.Equal(t, 0, counter["fail_charts"])
+	assert.Equal(t, 2, counter["normal_collect"])
+	assert.Equal(t, 0, counter["fail_collect"])
+	assert.Equal(t, 1, counter["normal_cleanup"])
+	assert.Equal(t, 1, counter["fail_cleanup"])
+}
+
 func TestOrchestrator_Serve(t *testing.T) {
 	o := New()
 	o.Name = "test.d"


### PR DESCRIPTION
# What

call cleanup when job check is failed

# Why

Jobs may open file, socket, etc. on check. 
We should close those resources on cleanup even if check is failed.