### PR TITLE
file discovery: correctly handle an empty file

### DIFF
--- a/job/discovery/file/parse.go
+++ b/job/discovery/file/parse.go
@@ -10,6 +10,15 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type format int
+
+const (
+	unknownFormat format = iota
+	unknownEmptyFormat
+	staticFormat
+	sdFormat
+)
+
 func parse(req confgroup.Registry, path string) (*confgroup.Group, error) {
 	bs, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -24,6 +33,8 @@ func parse(req confgroup.Registry, path string) (*confgroup.Group, error) {
 		return parseStaticFormat(req, path, bs)
 	case sdFormat:
 		return parseSDFormat(req, path, bs)
+	case unknownEmptyFormat:
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unknown file format: '%s'", path)
 	}
@@ -79,6 +90,10 @@ func cfgFormat(bs []byte) format {
 	if err := yaml.Unmarshal(bs, &data); err != nil {
 		return unknownFormat
 	}
+	if data == nil {
+		return unknownEmptyFormat
+	}
+
 	type (
 		static = map[interface{}]interface{}
 		sd     = []interface{}

--- a/job/discovery/file/parse_test.go
+++ b/job/discovery/file/parse_test.go
@@ -1,13 +1,12 @@
 package file
 
 import (
+	"github.com/netdata/go-orchestrator/module"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/netdata/go-orchestrator/job/confgroup"
-	"github.com/netdata/go-orchestrator/module"
-
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestParse(t *testing.T) {
@@ -56,10 +55,10 @@ func TestParse(t *testing.T) {
 				},
 			}
 
-			groups, err := parse(reg, filename)
+			group, err := parse(reg, filename)
 
 			require.NoError(t, err)
-			assert.Equal(t, expected, groups)
+			assert.Equal(t, expected, group)
 		},
 		"static, default: +job +conf +module (merge all)": func(t *testing.T, tmp *tmpDir) {
 			reg := confgroup.Registry{
@@ -94,10 +93,10 @@ func TestParse(t *testing.T) {
 				},
 			}
 
-			groups, err := parse(reg, filename)
+			group, err := parse(reg, filename)
 
 			require.NoError(t, err)
-			assert.Equal(t, expected, groups)
+			assert.Equal(t, expected, group)
 		},
 		"static, default: -job +conf +module": func(t *testing.T, tmp *tmpDir) {
 			reg := confgroup.Registry{
@@ -135,10 +134,10 @@ func TestParse(t *testing.T) {
 				},
 			}
 
-			groups, err := parse(reg, filename)
+			group, err := parse(reg, filename)
 
 			require.NoError(t, err)
-			assert.Equal(t, expected, groups)
+			assert.Equal(t, expected, group)
 		},
 		"static, default: -job -conf +module": func(t *testing.T, tmp *tmpDir) {
 			reg := confgroup.Registry{
@@ -171,10 +170,10 @@ func TestParse(t *testing.T) {
 				},
 			}
 
-			groups, err := parse(reg, filename)
+			group, err := parse(reg, filename)
 
 			require.NoError(t, err)
-			assert.Equal(t, expected, groups)
+			assert.Equal(t, expected, group)
 		},
 		"static, default: -job -conf -module (+global)": func(t *testing.T, tmp *tmpDir) {
 			reg := confgroup.Registry{
@@ -203,10 +202,10 @@ func TestParse(t *testing.T) {
 				},
 			}
 
-			groups, err := parse(reg, filename)
+			group, err := parse(reg, filename)
 
 			require.NoError(t, err)
-			assert.Equal(t, expected, groups)
+			assert.Equal(t, expected, group)
 		},
 		"sd, default: +job +module": func(t *testing.T, tmp *tmpDir) {
 			reg := confgroup.Registry{
@@ -241,10 +240,10 @@ func TestParse(t *testing.T) {
 				},
 			}
 
-			groups, err := parse(reg, filename)
+			group, err := parse(reg, filename)
 
 			require.NoError(t, err)
-			assert.Equal(t, expected, groups)
+			assert.Equal(t, expected, group)
 		},
 		"sd, default: -job +module": func(t *testing.T, tmp *tmpDir) {
 			reg := confgroup.Registry{
@@ -276,10 +275,10 @@ func TestParse(t *testing.T) {
 				},
 			}
 
-			groups, err := parse(reg, filename)
+			group, err := parse(reg, filename)
 
 			require.NoError(t, err)
-			assert.Equal(t, expected, groups)
+			assert.Equal(t, expected, group)
 		},
 		"sd, default: -job -module (+global)": func(t *testing.T, tmp *tmpDir) {
 			reg := confgroup.Registry{
@@ -307,10 +306,10 @@ func TestParse(t *testing.T) {
 				},
 			}
 
-			groups, err := parse(reg, filename)
+			group, err := parse(reg, filename)
 
 			require.NoError(t, err)
-			assert.Equal(t, expected, groups)
+			assert.Equal(t, expected, group)
 		},
 		"sd, job has no 'module' or 'module' is empty": func(t *testing.T, tmp *tmpDir) {
 			reg := confgroup.Registry{
@@ -329,10 +328,10 @@ func TestParse(t *testing.T) {
 				Configs: []confgroup.Config{},
 			}
 
-			groups, err := parse(reg, filename)
+			group, err := parse(reg, filename)
 
 			require.NoError(t, err)
-			assert.Equal(t, expected, groups)
+			assert.Equal(t, expected, group)
 		},
 		"conf registry has no module": func(t *testing.T, tmp *tmpDir) {
 			reg := confgroup.Registry{
@@ -352,10 +351,10 @@ func TestParse(t *testing.T) {
 				Configs: []confgroup.Config{},
 			}
 
-			groups, err := parse(reg, filename)
+			group, err := parse(reg, filename)
 
 			require.NoError(t, err)
-			assert.Equal(t, expected, groups)
+			assert.Equal(t, expected, group)
 		},
 		"empty file": func(t *testing.T, tmp *tmpDir) {
 			reg := confgroup.Registry{
@@ -363,18 +362,29 @@ func TestParse(t *testing.T) {
 			}
 
 			filename := tmp.createFile("empty-*")
-			groups, err := parse(reg, filename)
+			group, err := parse(reg, filename)
 
+			assert.Nil(t, group)
 			require.NoError(t, err)
-			assert.Nil(t, groups)
+		},
+		"only comments, unknown empty format": func(t *testing.T, tmp *tmpDir) {
+			reg := confgroup.Registry{}
+
+			filename := tmp.createFile("unknown-empty-format-*")
+			tmp.writeString(filename, "# a comment")
+			group, err := parse(reg, filename)
+
+			assert.Nil(t, group)
+			assert.NoError(t, err)
 		},
 		"unknown format": func(t *testing.T, tmp *tmpDir) {
 			reg := confgroup.Registry{}
 
 			filename := tmp.createFile("unknown-format-*")
 			tmp.writeYAML(filename, "unknown")
-			_, err := parse(reg, filename)
+			group, err := parse(reg, filename)
 
+			assert.Nil(t, group)
 			assert.Error(t, err)
 		},
 	}

--- a/job/discovery/file/read.go
+++ b/job/discovery/file/read.go
@@ -9,14 +9,6 @@ import (
 	"github.com/netdata/go-orchestrator/pkg/logger"
 )
 
-type format int
-
-const (
-	unknownFormat format = iota
-	staticFormat
-	sdFormat
-)
-
 type (
 	staticConfig struct {
 		confgroup.Default `yaml:",inline"`
@@ -66,12 +58,13 @@ func (r Reader) groups() (groups []*confgroup.Group) {
 				continue
 			}
 
-			group, err := parse(r.reg, path)
-			if err != nil {
+			if group, err := parse(r.reg, path); err != nil {
 				r.Warningf("parse '%s': %v", path, err)
-				continue
+			} else if group == nil {
+				groups = append(groups, &confgroup.Group{Source: path})
+			} else {
+				groups = append(groups, group)
 			}
-			groups = append(groups, group)
 		}
 	}
 	return groups

--- a/job/discovery/file/read_test.go
+++ b/job/discovery/file/read_test.go
@@ -35,19 +35,24 @@ func TestReader_Run(t *testing.T) {
 
 	module1 := tmp.join("module1.conf")
 	module2 := tmp.join("module2.conf")
+	module3 := tmp.join("module3.conf")
+
 	tmp.writeYAML(module1, staticConfig{
 		Jobs: []confgroup.Config{{"name": "name"}},
 	})
 	tmp.writeYAML(module2, staticConfig{
 		Jobs: []confgroup.Config{{"name": "name"}},
 	})
+	tmp.writeString(module3, "# a comment")
+
 	reg := confgroup.Registry{
 		"module1": {},
 		"module2": {},
+		"module3": {},
 	}
 	discovery := prepareDiscovery(t, Config{
 		Registry: reg,
-		Read:     []string{module1, module2},
+		Read:     []string{module1, module2, module3},
 	})
 	expected := []*confgroup.Group{
 		{
@@ -73,6 +78,9 @@ func TestReader_Run(t *testing.T) {
 					"priority":            module.Priority,
 				},
 			},
+		},
+		{
+			Source: module3,
 		},
 	}
 

--- a/job/discovery/file/sim_test.go
+++ b/job/discovery/file/sim_test.go
@@ -95,7 +95,7 @@ func (d *tmpDir) join(filename string) string {
 func (d *tmpDir) createFile(pattern string) string {
 	f, err := ioutil.TempFile(d.dir, pattern)
 	require.NoError(d.t, err)
-	f.Close()
+	_ = f.Close()
 	return f.Name()
 }
 
@@ -113,6 +113,11 @@ func (d *tmpDir) writeYAML(filename string, in interface{}) {
 	bs, err := yaml.Marshal(in)
 	require.NoError(d.t, err)
 	err = ioutil.WriteFile(filename, bs, 0644)
+	require.NoError(d.t, err)
+}
+
+func (d *tmpDir) writeString(filename, data string) {
+	err := ioutil.WriteFile(filename, []byte(data), 0644)
 	require.NoError(d.t, err)
 }
 

--- a/job/discovery/file/watch_test.go
+++ b/job/discovery/file/watch_test.go
@@ -71,6 +71,54 @@ func TestWatcher_Run(t *testing.T) {
 			}
 			return sim
 		},
+		"empty file": func(tmp *tmpDir) discoverySim {
+			reg := confgroup.Registry{
+				"module": {},
+			}
+			filename := tmp.join("module.conf")
+			discovery := prepareDiscovery(t, Config{
+				Registry: reg,
+				Watch:    []string{tmp.join("*.conf")},
+			})
+			expected := []*confgroup.Group{
+				{
+					Source: filename,
+				},
+			}
+
+			sim := discoverySim{
+				discovery: discovery,
+				beforeRun: func() {
+					tmp.writeString(filename, "")
+				},
+				expectedGroups: expected,
+			}
+			return sim
+		},
+		"only comments, no data": func(tmp *tmpDir) discoverySim {
+			reg := confgroup.Registry{
+				"module": {},
+			}
+			filename := tmp.join("module.conf")
+			discovery := prepareDiscovery(t, Config{
+				Registry: reg,
+				Watch:    []string{tmp.join("*.conf")},
+			})
+			expected := []*confgroup.Group{
+				{
+					Source: filename,
+				},
+			}
+
+			sim := discoverySim{
+				discovery: discovery,
+				beforeRun: func() {
+					tmp.writeString(filename, "# a comment")
+				},
+				expectedGroups: expected,
+			}
+			return sim
+		},
 		"add file": func(tmp *tmpDir) discoverySim {
 			reg := confgroup.Registry{
 				"module": {},


### PR DESCRIPTION
should send an empty group