### PR TITLE
netdataapi: set/variable/begin fix

### DIFF
--- a/pkg/netdataapi/api.go
+++ b/pkg/netdataapi/api.go
@@ -51,28 +51,28 @@ func (a *API) DIMENSION(
 // BEGIN initialize data collection for a chart.
 func (a *API) BEGIN(typeID string, ID string, msSince int) (err error) {
 	if msSince > 0 {
-		_, err = fmt.Fprintf(a, "BEGIN %s.%s %d\n", typeID, ID, msSince)
+		_, err = fmt.Fprintf(a, "BEGIN '%s.%s' %d\n", typeID, ID, msSince)
 	} else {
-		_, err = fmt.Fprintf(a, "BEGIN %s.%s\n", typeID, ID)
+		_, err = fmt.Fprintf(a, "BEGIN '%s.%s'\n", typeID, ID)
 	}
 	return err
 }
 
 // SET set the value of a dimension for the initialized chart.
 func (a *API) SET(ID string, value int64) error {
-	_, err := fmt.Fprintf(a, "SET %s = %d\n", ID, value)
+	_, err := fmt.Fprintf(a, "SET '%s' = %d\n", ID, value)
 	return err
 }
 
 // SETEMPTY set the empty value of a dimension for the initialized chart.
 func (a *API) SETEMPTY(ID string) error {
-	_, err := fmt.Fprintf(a, "SET %s = \n", ID)
+	_, err := fmt.Fprintf(a, "SET '%s' = \n", ID)
 	return err
 }
 
 // VARIABLE set the value of a CHART scope variable for the initialized chart.
 func (a *API) VARIABLE(ID string, value int64) error {
-	_, err := fmt.Fprintf(a, "VARIABLE CHART %s = %d\n", ID, value)
+	_, err := fmt.Fprintf(a, "VARIABLE CHART '%s' = %d\n", ID, value)
 	return err
 }
 

--- a/pkg/netdataapi/api_test.go
+++ b/pkg/netdataapi/api_test.go
@@ -66,7 +66,7 @@ func TestAPI_BEGIN(t *testing.T) {
 
 	assert.Equal(
 		t,
-		"BEGIN typeID.id\n",
+		"BEGIN 'typeID.id'\n",
 		b.String(),
 	)
 
@@ -80,7 +80,7 @@ func TestAPI_BEGIN(t *testing.T) {
 
 	assert.Equal(
 		t,
-		"BEGIN typeID.id 1\n",
+		"BEGIN 'typeID.id' 1\n",
 		b.String(),
 	)
 }
@@ -93,7 +93,7 @@ func TestAPI_SET(t *testing.T) {
 
 	assert.Equal(
 		t,
-		"SET id = 100\n",
+		"SET 'id' = 100\n",
 		b.String(),
 	)
 }
@@ -106,7 +106,7 @@ func TestAPI_SETEMPTY(t *testing.T) {
 
 	assert.Equal(
 		t,
-		"SET id = \n",
+		"SET 'id' = \n",
 		b.String(),
 	)
 }
@@ -119,7 +119,7 @@ func TestAPI_VARIABLE(t *testing.T) {
 
 	assert.Equal(
 		t,
-		"VARIABLE CHART id = 100\n",
+		"VARIABLE CHART 'id' = 100\n",
 		b.String(),
 	)
 }


### PR DESCRIPTION
this is needed to allow `=` in the dimenstion ids

problem: https://github.com/netdata/netdata/issues/9486#issuecomment-654165457